### PR TITLE
Update Documentation URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <packaging>hpi</packaging>
   <name>UrbanCode Velocity Plugin</name>
   <description>This plugin can run Jenkins jobs as a part of a deployment plan in UrbanCode Velocity.</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/IBM+Continuous+Release+Plugin</url>
+  <url>https://github.com/jenkinsci/urbancode-velocity-plugin</url>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Point documentation URL to GitHub, not Jenkins Wiki