### PR TITLE
Pass the startTime to the job status messages if we have a start time we

### DIFF
--- a/src/main/java/com/ibm/devops/connect/CloudRunListener.java
+++ b/src/main/java/com/ibm/devops/connect/CloudRunListener.java
@@ -56,6 +56,7 @@ public class CloudRunListener extends RunListener<Run> {
             } else {
                 status = new JenkinsJobStatus(run, cloudCause, null, listener, true, false);
             }
+            status.setRunStatus(true);
             JSONObject statusUpdate = status.generate(false);
             CloudPublisher.uploadJobStatus(statusUpdate);
         }
@@ -75,6 +76,7 @@ public class CloudRunListener extends RunListener<Run> {
             } else {
                 status = new JenkinsJobStatus(run, cloudCause, null, listener, false, false);
             }
+            status.setRunStatus(true);
             JSONObject statusUpdate = status.generate(true);
             CloudPublisher.uploadJobStatus(statusUpdate);
         }

--- a/src/main/java/com/ibm/devops/connect/Status/AbstractJenkinsStatus.java
+++ b/src/main/java/com/ibm/devops/connect/Status/AbstractJenkinsStatus.java
@@ -116,6 +116,7 @@ public abstract class AbstractJenkinsStatus {
             result.put("url", Jenkins.getInstance().getRootUrl() + run.getUrl());
             result.put("jobExternalId", getJobUniqueIdFromBuild());
             result.put("name", run.getDisplayName());
+            result.put("startTime", run.getStartTimeInMillis());
         } else {
             result.put("url", Jenkins.getInstance().getRootUrl());
             result.put("name", "Job Error");
@@ -253,6 +254,7 @@ public abstract class AbstractJenkinsStatus {
 
         result.put("status", status);
         result.put("timestamp", System.currentTimeMillis());
+        result.put("startTime", run.getStartTimeInMillis());
         result.put("syncId", Jenkins.getInstance().getDescriptorByType(DevOpsGlobalConfiguration.class).getSyncId());
         result.put("name", run.getDisplayName());
         result.put("steps", cloudCause.getStepsArray());

--- a/src/main/java/com/ibm/devops/connect/Status/AbstractJenkinsStatus.java
+++ b/src/main/java/com/ibm/devops/connect/Status/AbstractJenkinsStatus.java
@@ -58,6 +58,7 @@ public abstract class AbstractJenkinsStatus {
 
     protected Boolean isPipeline;
     protected Boolean isPaused;
+    protected Boolean isRunStatus;
 
     protected void getOrCreateCrAction() {
 
@@ -262,6 +263,7 @@ public abstract class AbstractJenkinsStatus {
         result.put("returnProps", cloudCause.getReturnProps());
         result.put("isPipeline", isPipeline);
         result.put("isPaused", isPaused);
+        result.put("isRunStatus", isRunStatus);
         result.put("jobName", run.getParent().getName());
         result.put("jobExternalId", getJobUniqueIdFromBuild());
         result.put("sourceData", cloudCause.getSourceDataJson());
@@ -272,7 +274,11 @@ public abstract class AbstractJenkinsStatus {
         return result;
     }
 
-    abstract protected FilePath getWorkspaceFilePath();
+	public void setRunStatus(Boolean isRunStatus) {
+		this.isRunStatus = isRunStatus;
+	}
+
+	abstract protected FilePath getWorkspaceFilePath();
 
     abstract protected void evaluatePipelineStep();
 


### PR DESCRIPTION
can send with the message.

This can then be used from within velocity when sending data to the build and deployments so that we know both when a build/deployment started on each message from jenkins as long as the run has started.