### PR TITLE
PLUGINS-3132 (Enhance Jenkins Plugin for Velocity)

### DIFF
--- a/src/main/resources/com/ibm/devops/connect/CRPipeline/UploadDeployment/config.jelly
+++ b/src/main/resources/com/ibm/devops/connect/CRPipeline/UploadDeployment/config.jelly
@@ -24,13 +24,13 @@
     <f:entry title="App Name (one of three required)" field="appName">
         <f:textbox />
     </f:entry>
+    <f:entry title="Version Name" field="versionName">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="Version External ID" field="versionExtId">
+        <f:textbox />
+    </f:entry>
     <f:advanced>
-        <f:entry title="Version Name" field="versionName">
-            <f:textbox />
-        </f:entry>
-        <f:entry title="Version External ID" field="versionExtId">
-            <f:textbox />
-        </f:entry>
         <f:entry title="Description" field="description">
             <f:textbox />
         </f:entry>


### PR DESCRIPTION
Salesforce case for the Velocity Jenkins plugin- TS004660800. The 'Upload Deployment' step wasn't working as expected for the customer. It looks like versionName and versionExternal ID was not filled by the customer and hence it was failing. The customer is using a free style Jenkins job and using the UI option to configure the upload Deployment step. The versionName and versionExternal ID are in Advanced options and he suggested moving it outside.